### PR TITLE
feat: simulate user fid on demand

### DIFF
--- a/components/FrameEditor.tsx
+++ b/components/FrameEditor.tsx
@@ -165,7 +165,7 @@ export default function FrameEditor({
                         <TooltipProvider delayDuration={0}>
                             <Tooltip>
                                 <TooltipTrigger asChild={true}>
-                                    <MockOptions />
+                                    <MockOptions fid={fid} />
                                 </TooltipTrigger>
                                 <TooltipContent className="max-w-72 flex flex-col gap-2">
                                     <p>

--- a/components/FramePreview.tsx
+++ b/components/FramePreview.tsx
@@ -198,6 +198,7 @@ function FrameButton({
 
     const confirmAction = useCallback(async () => {
         const fid = mockOptions.fid
+
         const result = await simulateCall(
             {
                 untrustedData: {

--- a/components/FramePreview.tsx
+++ b/components/FramePreview.tsx
@@ -24,8 +24,8 @@ const textFaint = '#9fa3af'
 
 export function FramePreview() {
     const [history, setHistory] = useAtom(previewHistoryAtom)
-	
-	useEffect(() => {
+
+    useEffect(() => {
         // reset preview when un-mounting (= navigating to another page)
         return () => {
             setHistory([])
@@ -197,10 +197,11 @@ function FrameButton({
     const { action, target } = button
 
     const confirmAction = useCallback(async () => {
+        const fid = mockOptions.fid
         const result = await simulateCall(
             {
                 untrustedData: {
-                    fid: 368382,
+                    fid,
                     url: target!,
                     messageHash: '0xDebug',
                     timestamp: 0,
@@ -209,7 +210,7 @@ function FrameButton({
                     inputText: inputText,
                     state: 'Debug',
                     castId: {
-                        fid: 368382,
+                        fid,
                         hash: '0xDebug',
                     },
                 },
@@ -219,9 +220,9 @@ function FrameButton({
             },
             mockOptions
         )
-		
-		if (!result) return
-		
+
+        if (!result) return
+
         setPreviewHistory((prev: any) => [...prev, result])
     }, [target, index, inputText, mockOptions, setPreviewHistory])
 

--- a/components/editor/MockOptions.tsx
+++ b/components/editor/MockOptions.tsx
@@ -14,18 +14,29 @@ import { mockOptionsAtom } from '@/lib/store'
 import { useAtom } from 'jotai'
 import { User } from 'lucide-react'
 import { useEffect, useState } from 'react'
+import { Input } from '../shadcn/Input'
 
-export default function MockOptions() {
+export default function MockOptions({ fid }: { fid: string }) {
     const [open, setOpen] = useState(false)
     const [mockOptions, setMockOptions] = useAtom(mockOptionsAtom)
+    const [simulatedFid, setSimulatedFid] = useState(Number.parseInt(fid))
 
     useEffect(() => {
-        // we reset the mock options
-        setMockOptions([])
+        if (mockOptions.fid > 0) return
+        if (mockOptions.fid === simulatedFid) return
+        setMockOptions((prev) => ({ ...prev, fid: simulatedFid }))
 
-        // undefined so when we visit a Frame that doesn't require validation, this doesn't stay in memory
-        return () => setMockOptions(undefined)
-    }, [setMockOptions])
+        return () => {
+            // reset fid as the only default mock option
+            setMockOptions(() => ({
+                recasted: false,
+                liked: false,
+                follower: false,
+                following: false,
+                fid: simulatedFid,
+            }))
+        }
+    }, [mockOptions, setMockOptions, simulatedFid])
 
     return (
         <DropdownMenu open={open}>
@@ -44,15 +55,9 @@ export default function MockOptions() {
                         <User className="mr-2 h-4 w-4" />
                         <span className="w-full">Recasted</span>
                         <Switch
-                            checked={mockOptions?.includes('recasted')}
-                            onCheckedChange={(checked) => {
-                                if (checked) {
-                                    setMockOptions([...(mockOptions || []), 'recasted'])
-                                } else {
-                                    setMockOptions(
-                                        mockOptions?.filter((option) => option !== 'recasted')
-                                    )
-                                }
+                            checked={mockOptions.recasted}
+                            onCheckedChange={(recasted) => {
+                                setMockOptions((prev) => ({ ...prev, recasted }))
                             }}
                         />
                     </DropdownMenuItem>
@@ -60,15 +65,9 @@ export default function MockOptions() {
                         <User className="mr-2 h-4 w-4" />
                         <span className="w-full">Liked</span>
                         <Switch
-                            checked={mockOptions?.includes('liked')}
-                            onCheckedChange={(checked) => {
-                                if (checked) {
-                                    setMockOptions([...(mockOptions || []), 'liked'])
-                                } else {
-                                    setMockOptions(
-                                        mockOptions?.filter((option) => option !== 'liked')
-                                    )
-                                }
+                            checked={mockOptions.liked}
+                            onCheckedChange={(liked) => {
+                                setMockOptions((prev) => ({ ...prev, liked }))
                             }}
                         />
                     </DropdownMenuItem>
@@ -76,15 +75,12 @@ export default function MockOptions() {
                         <User className="mr-2 h-4 w-4" />
                         <span className="w-full">Following</span>
                         <Switch
-                            checked={mockOptions?.includes('following')}
-                            onCheckedChange={(checked) => {
-                                if (checked) {
-                                    setMockOptions([...(mockOptions || []), 'following'])
-                                } else {
-                                    setMockOptions(
-                                        mockOptions?.filter((option) => option !== 'following')
-                                    )
-                                }
+                            checked={mockOptions.following}
+                            onCheckedChange={(following) => {
+                                setMockOptions((prev) => ({
+                                    ...prev,
+                                    following,
+                                }))
                             }}
                         />
                     </DropdownMenuItem>
@@ -92,27 +88,35 @@ export default function MockOptions() {
                         <User className="mr-2 h-4 w-4" />
                         <span className="w-full">Follower</span>
                         <Switch
-                            checked={mockOptions?.includes('follower')}
-                            onCheckedChange={(checked) => {
-                                if (checked) {
-                                    setMockOptions([...(mockOptions || []), 'follower'])
-                                } else {
-                                    setMockOptions(
-                                        mockOptions?.filter((option) => option !== 'follower')
-                                    )
-                                }
+                            checked={mockOptions.follower}
+                            onCheckedChange={(follower) => {
+                                setMockOptions((prev) => ({ ...prev, follower }))
                             }}
                         />
                     </DropdownMenuItem>
                 </DropdownMenuGroup>
 
-                {/* <DropdownMenuSeparator />
+                <DropdownMenuSeparator />
 
-                <DropdownMenuItem>
-                    <LogOut className="mr-2 h-4 w-4" />
-                    <span>FID</span>
-                    <DropdownMenuShortcut>⇧⌘Q</DropdownMenuShortcut>
-                </DropdownMenuItem> */}
+                <DropdownMenuItem className="hover:bg-none">
+                    <div className="flex flex-col w-full h-full">
+                        <span>FID:</span>
+                        <Input
+                            type="number"
+                            defaultValue={simulatedFid}
+                            className="hover:border"
+                            onChange={async (e) => {
+                                e.preventDefault()
+                                const fid = Number.parseInt(e.target.value)
+
+                                setTimeout(() => {
+                                    setMockOptions((prev) => ({ ...prev, fid }))
+                                    setSimulatedFid(fid)
+                                }, 1500)
+                            }}
+                        />
+                    </div>
+                </DropdownMenuItem>
             </DropdownMenuContent>
         </DropdownMenu>
     )

--- a/components/editor/MockOptions.tsx
+++ b/components/editor/MockOptions.tsx
@@ -19,13 +19,19 @@ import { Input } from '../shadcn/Input'
 export default function MockOptions({ fid }: { fid: string }) {
     const [open, setOpen] = useState(false)
     const [mockOptions, setMockOptions] = useAtom(mockOptionsAtom)
-    const [simulatedFid, setSimulatedFid] = useState(Number.parseInt(fid))
 
     useEffect(() => {
         if (mockOptions.fid > 0) return
-        if (mockOptions.fid === simulatedFid) return
-        setMockOptions((prev) => ({ ...prev, fid: simulatedFid }))
+        setMockOptions(() => ({
+            recasted: false,
+            liked: false,
+            follower: false,
+            following: false,
+            fid: Number.parseInt(fid),
+        }))
+    }, [fid, mockOptions.fid, setMockOptions])
 
+    useEffect(() => {
         return () => {
             // reset fid as the only default mock option
             setMockOptions(() => ({
@@ -33,10 +39,10 @@ export default function MockOptions({ fid }: { fid: string }) {
                 liked: false,
                 follower: false,
                 following: false,
-                fid: simulatedFid,
+                fid: 0,
             }))
         }
-    }, [mockOptions, setMockOptions, simulatedFid])
+    }, [setMockOptions])
 
     return (
         <DropdownMenu open={open}>
@@ -99,23 +105,17 @@ export default function MockOptions({ fid }: { fid: string }) {
                 <DropdownMenuSeparator />
 
                 <DropdownMenuItem className="hover:bg-none">
-                    <div className="flex flex-col w-full h-full">
-                        <span>FID:</span>
-                        <Input
-                            type="number"
-                            defaultValue={simulatedFid}
-                            className="hover:border"
-                            onChange={async (e) => {
-                                e.preventDefault()
-                                const fid = Number.parseInt(e.target.value)
-
-                                setTimeout(() => {
-                                    setMockOptions((prev) => ({ ...prev, fid }))
-                                    setSimulatedFid(fid)
-                                }, 1500)
-                            }}
-                        />
-                    </div>
+                    <span className="w-full">FID</span>
+                    <Input
+                        type="number"
+                        defaultValue={mockOptions.fid}
+                        onChange={async (e) => {
+                            const fid = Number.parseInt(e.target.value)
+                            setTimeout(() => {
+                                setMockOptions((prev) => ({ ...prev, fid }))
+                            }, 1500)
+                        }}
+                    />
                 </DropdownMenuItem>
             </DropdownMenuContent>
         </DropdownMenu>

--- a/lib/debugger.ts
+++ b/lib/debugger.ts
@@ -25,13 +25,9 @@ export async function simulateCall(frameData: FrameRequest, options: MockOptions
         ...frameData,
     } as any
 
-    const enabledOptions = Object.keys(options).filter((k) => {
-        const key = k as keyof MockOptions
-        if (key === 'fid') return false
-        return options[key]
-    })
+    const hasOptions = Object.values(options).some(Boolean)
 
-    if (options.fid > 0 || enabledOptions.length) {
+    if (hasOptions) {
         const timestamp = new Date().toISOString()
         const isRecasted = options.recasted
         const isLiked = options.liked

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -3,4 +3,18 @@ import type { getPreview } from './debugger'
 
 export const previewHistoryAtom = atom<Awaited<ReturnType<typeof getPreview>>[]>([])
 
-export const mockOptionsAtom = atom<string[] | undefined>(undefined)
+export type MockOptions = {
+    fid: number
+    recasted: boolean
+    liked: boolean
+    following: boolean
+    follower: boolean
+}
+
+export const mockOptionsAtom = atom<MockOptions>({
+    fid: 0,
+    recasted: false,
+    liked: false,
+    following: false,
+    follower: false,
+})


### PR DESCRIPTION
- Add input field beneath the switch option in the simulation popover
- Turn mockOptions atom from array of strings to an object of key-value pairs
- Set the default simulated fid to that of the authenticated user
- Simulation will only work if fid is > 0 or at least one of the other flags is true


Video demo (slow network so google fonts took time to load)
https://www.loom.com/share/37d0df81bee3460db3b8dfde6a4372d0

closes #35