### PR TITLE
CAL: Allow for multiple slugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ next-env.d.ts
 .vscode
 .work
 .tw
+frametrain.sqlite

--- a/templates/cal/Inspector.tsx
+++ b/templates/cal/Inspector.tsx
@@ -174,7 +174,7 @@ export default function Inspector() {
 
                                         updateConfig({ events: newEvents })
                                     } catch (_) {
-                                        toast.error(`No Event Type found for: ${eventSlug}`)
+                                        toast.error(`No event type found for: ${eventSlug}`)
                                     } finally {
                                         setLoading(false)
 

--- a/templates/cal/Inspector.tsx
+++ b/templates/cal/Inspector.tsx
@@ -27,6 +27,9 @@ export default function Inspector() {
     const fid = useFarcasterId()
 
     const handleSubmit = async (username: string, eventSlug: string) => {
+        if (username === '' || eventSlug === '') return
+        if (config.username === username && config.eventSlug === eventSlug) return
+
         corsFetch(
             `https://cal.com/api/trpc/public/event?batch=1&input={"0":{"json":{"username":"${username}","eventSlug":"${eventSlug}","isTeamEvent":false,"org":null}}}`,
             {
@@ -38,15 +41,26 @@ export default function Inspector() {
         )
             .then((text) => {
                 const data = JSON.parse(text as string)
-                const img = data[0].result.data.json.profile.image
+                const json = data[0].result.data.json
+
+                if (json === null) {
+                    updateConfig({
+                        username: username,
+                        eventSlug: eventSlug,
+                        fid,
+                    })
+                    return
+                }
+
+                const image = data[0].result.data.json.profile.image
                 const name = data[0].result.data.json.profile.name
-                console.log(img, name)
 
                 updateConfig({
-                    image: img,
-                    name: name,
-                    username: username,
-                    fid: fid,
+                    image,
+                    name,
+                    username,
+                    eventSlug,
+                    fid,
                 })
             })
             .catch((error) => console.error('Error:', error))
@@ -89,7 +103,6 @@ export default function Inspector() {
         })
     }
     const handleChainChange = (value: any) => {
-        console.log(value)
         updateConfig({
             nftOptions: {
                 ...config.nftOptions,
@@ -98,7 +111,6 @@ export default function Inspector() {
         })
     }
     const handleNftTypeChange = (value: any) => {
-        console.log(value)
         updateConfig({
             nftOptions: {
                 ...config.nftOptions,

--- a/templates/cal/Inspector.tsx
+++ b/templates/cal/Inspector.tsx
@@ -39,10 +39,11 @@ export default function Inspector() {
 
         if (username === '') {
             updateConfig({
-                fid: undefined,
                 name: undefined,
                 username: undefined,
                 image: undefined,
+                bio: [],
+                fid: undefined,
                 events: [],
             })
             return

--- a/templates/cal/Inspector.tsx
+++ b/templates/cal/Inspector.tsx
@@ -58,7 +58,7 @@ export default function Inspector() {
                 fid,
                 events: [],
             })
-        } catch (_) {}
+        } catch {}
     }, 1000)
 
     const handleNFT = async (nftAddress: string) => {
@@ -162,7 +162,7 @@ export default function Inspector() {
                                         ]
 
                                         updateConfig({ events: newEvents })
-                                    } catch (_) {
+                                    } catch {
                                         toast.error(`No event type found for: ${eventSlug}`)
                                     } finally {
                                         setLoading(false)

--- a/templates/cal/functions/date.ts
+++ b/templates/cal/functions/date.ts
@@ -20,14 +20,13 @@ export default async function dateHanlder(
     const buttonIndex = body.untrustedData.buttonIndex
 
     let date = params?.date === undefined || params?.date === 'NaN' ? 0 : Number(params?.date)
-    let durationTime = '0'
-    let eventSlug = ''
+    const eventIndex = params?.eventSlug
+        ? config.events.findIndex((event) => event.slug === params.eventSlug)
+        : buttonIndex - 1
+    const event = config.events[eventIndex]
 
     switch (buttonIndex) {
         case 2: {
-            eventSlug = config.events[buttonIndex - 1].slug
-            durationTime = config.events[buttonIndex - 1].formattedDuration
-
             if (params.date === undefined) {
                 break
             }
@@ -38,7 +37,7 @@ export default async function dateHanlder(
                     json: {
                         isTeamEvent: false,
                         usernameList: [`${config.username}`],
-                        eventTypeSlug: eventSlug,
+                        eventTypeSlug: event.slug,
                         startTime: dates[0],
                         endTime: dates[1],
                         timeZone: 'UTC',
@@ -76,33 +75,24 @@ export default async function dateHanlder(
                 component: NextView(config, slotsArray[date], 0),
                 functionName: 'slot',
                 params: {
-                    duration: eventSlug,
+                    duration: event.slug,
                     date,
                     slot: 0,
-                    durationTime: durationTime,
                     slotLength: slotsArray[date].length,
                 },
             }
         }
 
         default: {
-            if (!params.date) {
-                const event = config.events[buttonIndex - 1]
-                eventSlug = event.slug
-                durationTime = event.formattedDuration
-            } else {
-                if (buttonIndex === 1 || buttonIndex == 3) {
-                    date =
-                        buttonIndex === 1
-                            ? date == 0
-                                ? params.dateLength - 1
-                                : date - 1
-                            : date == params.dateLength - 1
-                              ? 0
-                              : date + 1
-                }
-                eventSlug = params.eventSlug
-                durationTime = params.durationTime
+            if (buttonIndex === 1 || buttonIndex == 3) {
+                date =
+                    buttonIndex === 1
+                        ? date == 0
+                            ? params.dateLength - 1
+                            : date - 1
+                        : date == params.dateLength - 1
+                          ? 0
+                          : date + 1
             }
         }
     }
@@ -113,7 +103,7 @@ export default async function dateHanlder(
             json: {
                 isTeamEvent: false,
                 usernameList: [`${config.username}`],
-                eventTypeSlug: eventSlug,
+                eventTypeSlug: event.slug,
                 startTime: dates[0],
                 endTime: dates[1],
                 timeZone: 'UTC',
@@ -151,12 +141,11 @@ export default async function dateHanlder(
             },
         ],
         fonts,
-        component: PageView(config, datesArray, date, durationTime),
+        component: PageView(config, datesArray, date, event.formattedDuration),
         functionName: 'date',
         params: {
             date,
-            eventSlug,
-            durationTime,
+            eventSlug: event.slug,
             dateLength: datesArray.length,
         },
     }

--- a/templates/cal/functions/duration.ts
+++ b/templates/cal/functions/duration.ts
@@ -150,7 +150,6 @@ export default async function duration(
             params: {
                 date: 0,
                 eventSlug: event.slug,
-                durationTime: event.formattedDuration,
                 dateLength: datesArray.length,
             },
             functionName: 'date',

--- a/templates/cal/functions/duration.ts
+++ b/templates/cal/functions/duration.ts
@@ -1,10 +1,16 @@
 'use server'
 import type { BuildFrameData, FrameActionPayloadValidated } from '@/lib/farcaster'
 import { loadGoogleFontAllVariants } from '@/sdk/fonts'
-import type { Config, State } from '..'
-import { balances721, balancesERC1155 } from '../utils/balances'
-import PageView from '../views/Duration'
 import { FrameError } from '@/sdk/handlers'
+
+import type { Config, State } from '..'
+
+import { balances721, balancesERC1155 } from '../utils/balances'
+
+import DateView from '../views/Date'
+import PageView from '../views/Duration'
+import { getCurrentAndFutureDate } from '../utils/getDays'
+import { extractDatesAndSlots } from '../utils/extractDatesAndSlots'
 
 export default async function duration(
     body: FrameActionPayloadValidated,
@@ -22,6 +28,10 @@ export default async function duration(
 
     let containsUserFID = true
     let nftGate = true
+
+    if ((config.events || []).length === 0) {
+        throw new FrameError('No events available to schedule.')
+    }
 
     if (
         config.gatingOptions.follower &&
@@ -57,8 +67,8 @@ export default async function duration(
             containsUserFID = data.result.some(
                 (item: any) => item.fid === body.validatedData.interactor.fid
             )
-        } catch (error) {
-            console.log(error)
+        } catch (_) {
+            throw new FrameError('Failed to fetch your engagement data')
         }
     }
 
@@ -90,15 +100,67 @@ export default async function duration(
         throw new FrameError(`You need to hold ${config.nftOptions.nftName} to schedule a call.`)
     }
 
+    if (config.events.length === 1) {
+        const event = config.events[0]
+        const dates = getCurrentAndFutureDate(30)
+        const url = `https://cal.com/api/trpc/public/slots.getSchedule?input=${encodeURIComponent(
+            JSON.stringify({
+                json: {
+                    isTeamEvent: false,
+                    usernameList: [`${config.username}`],
+                    eventTypeSlug: event.slug,
+                    startTime: dates[0],
+                    endTime: dates[1],
+                    timeZone: 'UTC',
+                    duration: null,
+                    rescheduleUid: null,
+                    orgSlug: null,
+                },
+                meta: {
+                    values: {
+                        duration: ['undefined'],
+                        orgSlug: ['undefined'],
+                    },
+                },
+            })
+        )}`
+
+        const slots = await fetch(url)
+        const slotsResponse = await slots.json()
+        const [datesArray] = extractDatesAndSlots(slotsResponse.result.data.json.slots)
+
+        if (!datesArray.length) {
+            throw new FrameError('No events available to schedule.')
+        }
+
+        return {
+            fonts,
+            buttons: [
+                {
+                    label: '⬅️',
+                },
+                {
+                    label: 'Select',
+                },
+                {
+                    label: '➡️',
+                },
+            ],
+            component: DateView(config, datesArray, 0, event.formattedDuration),
+            params: {
+                date: 0,
+                eventSlug: event.slug,
+                durationTime: event.formattedDuration,
+                dateLength: datesArray.length,
+            },
+            functionName: 'date',
+        }
+    }
+
     return {
-        buttons: [
-            {
-                label: '15min',
-            },
-            {
-                label: '30min',
-            },
-        ],
+        buttons: config.events.map((event) => ({
+            label: event.formattedDuration,
+        })),
         fonts: fonts,
 
         component: PageView(config),

--- a/templates/cal/functions/duration.ts
+++ b/templates/cal/functions/duration.ts
@@ -67,7 +67,7 @@ export default async function duration(
             containsUserFID = data.result.some(
                 (item: any) => item.fid === body.validatedData.interactor.fid
             )
-        } catch (_) {
+        } catch {
             throw new FrameError('Failed to fetch your engagement data')
         }
     }

--- a/templates/cal/index.ts
+++ b/templates/cal/index.ts
@@ -5,7 +5,11 @@ import functions from './functions'
 
 export interface Config extends BaseConfig {
     username: string
-    eventSlug: string
+    events: {
+        slug: string
+        duration: string
+        formattedDuration: string
+    }[]
     fontFamily?: string
     primaryColor?: string
     secondaryColor?: string
@@ -46,7 +50,7 @@ export default {
     Inspector,
     functions,
     initialConfig: {
-        eventSlug: '15min',
+        events: [],
         username: 'cal.com',
         gatingOptions: {
             karmaGating: false,

--- a/templates/cal/index.ts
+++ b/templates/cal/index.ts
@@ -16,6 +16,7 @@ export interface Config extends BaseConfig {
     image: string | undefined
     name: string | undefined
     username: string | undefined
+    bio: string[]
     events: {
         slug: string
         duration: string
@@ -52,6 +53,7 @@ export default {
     functions,
     initialConfig: {
         events: [],
+        bio: [],
         gatingOptions: {
             karmaGating: false,
             nftGating: false,

--- a/templates/cal/index.ts
+++ b/templates/cal/index.ts
@@ -5,6 +5,7 @@ import functions from './functions'
 
 export interface Config extends BaseConfig {
     username: string
+    eventSlug: string
     fontFamily?: string
     primaryColor?: string
     secondaryColor?: string
@@ -45,6 +46,8 @@ export default {
     Inspector,
     functions,
     initialConfig: {
+        eventSlug: '15min',
+        username: 'cal.com',
         gatingOptions: {
             karmaGating: false,
             nftGating: false,

--- a/templates/cal/index.ts
+++ b/templates/cal/index.ts
@@ -4,12 +4,6 @@ import cover from './cover.jpg'
 import functions from './functions'
 
 export interface Config extends BaseConfig {
-    username: string
-    events: {
-        slug: string
-        duration: string
-        formattedDuration: string
-    }[]
     fontFamily?: string
     primaryColor?: string
     secondaryColor?: string
@@ -17,9 +11,16 @@ export interface Config extends BaseConfig {
     titleStyle?: string
     background?: string
     bodyColor?: string
-    fid: number
-    image: string
-    name: string
+
+    fid: number | undefined
+    image: string | undefined
+    name: string | undefined
+    username: string | undefined
+    events: {
+        slug: string
+        duration: string
+        formattedDuration: string
+    }[]
 
     gatingOptions: {
         karmaGating: boolean
@@ -51,7 +52,6 @@ export default {
     functions,
     initialConfig: {
         events: [],
-        username: 'cal.com',
         gatingOptions: {
             karmaGating: false,
             nftGating: false,

--- a/templates/cal/utils/dayjs.ts
+++ b/templates/cal/utils/dayjs.ts
@@ -1,0 +1,8 @@
+import dayjs from 'dayjs'
+import duration from 'dayjs/plugin/duration'
+import utc from 'dayjs/plugin/utc'
+
+dayjs.extend(duration)
+dayjs.extend(utc)
+
+export default dayjs

--- a/templates/cal/utils/fetchData.ts
+++ b/templates/cal/utils/fetchData.ts
@@ -1,0 +1,21 @@
+import { corsFetch } from '@/sdk/scrape'
+
+export async function fetchProfileData(username: string) {
+    const response = await corsFetch(`https://cal.com/${username}`)
+    if (!response) return null
+
+    const parser = new DOMParser()
+    const parsedhtml = parser.parseFromString(response, 'text/html')
+    if (!parsedhtml) return null
+
+    const data = parsedhtml.getElementById('__NEXT_DATA__')
+    if (!data?.textContent) return null
+
+    const obj = JSON.parse(data.textContent)
+    const profile = obj?.props?.pageProps?.profile as {
+        name: string
+        username: string
+        image: string
+    } | null
+    return profile
+}

--- a/templates/cal/utils/fetchData.ts
+++ b/templates/cal/utils/fetchData.ts
@@ -1,21 +1,43 @@
 import { corsFetch } from '@/sdk/scrape'
 
-export async function fetchProfileData(username: string) {
-    const response = await corsFetch(`https://cal.com/${username}`)
+export async function fetchProfileData(slug: string) {
+    const response = await corsFetch(`https://cal.com/${slug}`)
     if (!response) return null
 
     const parser = new DOMParser()
     const parsedhtml = parser.parseFromString(response, 'text/html')
     if (!parsedhtml) return null
 
-    const data = parsedhtml.getElementById('__NEXT_DATA__')
-    if (!data?.textContent) return null
+    const nextData = parsedhtml.getElementById('__NEXT_DATA__')
+    if (!nextData?.textContent) return null
 
-    const obj = JSON.parse(data.textContent)
-    const profile = obj?.props?.pageProps?.profile as {
+    const obj = JSON.parse(nextData.textContent)?.props?.pageProps
+    const profile = obj?.profile as {
         name: string
         username: string
         image: string
     } | null
-    return profile
+
+    const bio: string[] = []
+
+    console.log({ profile, obj })
+
+    if (obj.safeBio.length) {
+        // Parse the bio to get the text content only of each child element
+        const body = parser.parseFromString(obj.safeBio, 'text/html').body.children
+        for (const child of body) {
+            if (child.textContent) bio.push(child.textContent)
+        }
+    }
+
+    const data = profile
+        ? {
+              name: profile.name,
+              username: profile.username,
+              image: profile.image,
+              bio,
+          }
+        : undefined
+
+    return data
 }

--- a/templates/cal/utils/getDays.ts
+++ b/templates/cal/utils/getDays.ts
@@ -15,3 +15,34 @@ export function getCurrentAndFutureDate(days: number) {
 
     return [formattedCurrentDate, formattedFutureDate]
 }
+
+/**
+ * Render X mins as X hours or X hours Y mins instead of in minutes once >= 60 minutes
+ * @see {@link https://github.com/calcom/cal.com/blob/main/packages/features/bookings/components/event-meta/Duration.tsx#L12}
+ * @example getDurationFormatted(90) => '1 hour 30 minutes'
+ * @example getDurationFormatted(60) => '1 hour'
+ * @example getDurationFormatted(30) => '30 minutes'
+ * @example getDurationFormatted(1) => '1 minute'
+ *
+ * @param mins - number of minutes
+ * @returns formatted string
+ **/
+export const getDurationFormatted = (mins: number | undefined) => {
+    if (!mins) return null
+
+    const hours = Math.floor(mins / 60)
+    const minutes = mins % 60
+    // format minutes string
+    let minStr = ''
+    if (minutes > 0) {
+        minStr = `${minutes} ${minutes === 1 ? 'minute' : 'minutes'}`
+    }
+    // format hours string
+    let hourStr = ''
+    if (hours > 0) {
+        hourStr = `${hours} ${hours === 1 ? 'hour' : 'hours'}`
+    }
+
+    if (hourStr && minStr) return `${hourStr} ${minStr}`
+    return hourStr || minStr
+}

--- a/templates/cal/views/Cover.tsx
+++ b/templates/cal/views/Cover.tsx
@@ -17,7 +17,6 @@ export default function CoverView(config: Config) {
             style={{
                 width: '100%',
                 height: '100%',
-
                 display: 'flex',
                 flexDirection: 'column',
                 textAlign: 'center',
@@ -83,6 +82,31 @@ export default function CoverView(config: Config) {
                     </div>
                 </div>
             </div>
+            {config.bio.length ? (
+                <div
+                    style={{
+                        display: 'flex',
+                        flexDirection: 'column',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        gap: 15,
+                        marginBottom: '2rem',
+                    }}
+                >
+                    {config.bio.map((bio) => (
+                        <div
+                            style={{
+                                overflowWrap: 'break-word',
+                                fontSize: '30px',
+                                lineHeight: '1.25rem',
+                            }}
+                            key={bio}
+                        >
+                            {bio}
+                        </div>
+                    ))}
+                </div>
+            ) : null}
 
             {config.gatingOptions.nftGating ? (
                 <div

--- a/templates/cal/views/Cover.tsx
+++ b/templates/cal/views/Cover.tsx
@@ -12,6 +12,9 @@ export default function CoverView(config: Config) {
         backgroundProp['backgroundColor'] = '#black'
     }
 
+    const paragraphs =
+        config.bio.length > 2 ? [config.bio[0], config.bio[config.bio.length - 1]] : config.bio
+
     return (
         <div
             style={{
@@ -93,16 +96,16 @@ export default function CoverView(config: Config) {
                         marginBottom: '2rem',
                     }}
                 >
-                    {config.bio.map((bio) => (
+                    {paragraphs.map((bio) => (
                         <div
                             style={{
                                 overflowWrap: 'break-word',
                                 fontSize: '30px',
-                                lineHeight: '1.25rem',
+                                lineHeight: '2.5rem',
                             }}
                             key={bio}
                         >
-                            {bio}
+                            {bio.length > 90 ? bio.slice(0, 90) + '...' : bio}
                         </div>
                     ))}
                 </div>

--- a/templates/cal/views/Date.tsx
+++ b/templates/cal/views/Date.tsx
@@ -3,7 +3,6 @@ import { months } from '../utils/const'
 
 export default function CoverView(
     config: Config,
-    duration: string,
     dates: string[],
     dateParam: number,
     mins: string
@@ -122,7 +121,9 @@ export default function CoverView(
                     style={{
                         display: 'flex',
                     }}
-                >{`${mins} mins`}</div>
+                >
+                    {mins}
+                </div>
             </div>
             <div
                 style={{


### PR DESCRIPTION
Prior to this PR, the inspector was pulling event data from cal.com's api for the default event slug that everyone gets upon signup `15min`. If you do not have any event with the `15min` slug then no data will be returned when you use your username.
So this PR aims to allow `Users` set their own event slug alongside their username.

- Set default username to `cal.com` and eventSlug to `15min`
- Fetch initial data when `config.name` isn't available, meaning it's freshly created frame without any data that was fetch from the api

https://www.loom.com/share/e6f2fe5108e849c292ea3b45d0e46640