### PR TITLE
revert(luma): set geo types and objects to previous versions

### DIFF
--- a/templates/luma/Inspector.tsx
+++ b/templates/luma/Inspector.tsx
@@ -38,12 +38,12 @@ export default function Inspector() {
         }
         const geo = eventData?.geo_address_info as {
             obfuscated: boolean
-            citystorage: string
+            city_state: string
         } | null
         let address = 'N/A'
 
         if (eventData?.location_type === 'offline' && geo) {
-            address = `${capitalize(geo.citystorage)} (OFFLINE)`
+            address = `${capitalize(geo.city_state)} (OFFLINE)`
         } else if (eventData?.location_type !== 'offline') {
             address = `${capitalize(eventData.location_type)} (ONLINE)`
         }


### PR DESCRIPTION
In https://github.com/FTCHD/frametrain/pull/78/commits/dfe4225ed2015a4128df7d9f84c6e73115d28651#diff-0119787ce00b6d9c7cc7f27cb179fa2abf7244940be8ec036339ad4e0b00d592L41, information on geo details were mistakenly changed thus breaking  generating an event card for a luma event. This PR aims to revert that change