### PR TITLE
[sdk] Fix return type of useFramePreview()

### DIFF
--- a/sdk/hooks.ts
+++ b/sdk/hooks.ts
@@ -66,9 +66,7 @@ export function useUploadImage() {
 }
 
 export function useFramePreview() {
-    const [previewData, setPreviewData] = useAtom(previewParametersAtom)
-
-    return [previewData, setPreviewData]
+    return useAtom(previewParametersAtom)
 }
 
 export function useResetPreview() {


### PR DESCRIPTION
Signature before:

```typescript
function useFramePreview(): ({
    handler?: string;
    buttonIndex: number;
    inputText?: string;
    params?: string;
} | SetAtom<[SetStateAction<{
    handler?: string;
    buttonIndex: number;
    inputText?: string;
    params?: string;
} | undefined>], void> | undefined)[]
```

Signature after:

```typescript
function useFramePreview(): [{
    handler?: string;
    buttonIndex: number;
    inputText?: string;
    params?: string;
} | undefined, SetAtom<[SetStateAction<{
    handler?: string;
    buttonIndex: number;
    inputText?: string;
    params?: string;
} | undefined>], void>]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `useFramePreview` function for improved efficiency and simplicity in state management.

- **Bug Fixes**
	- Addressed issues related to state handling within the `useFramePreview` function, resulting in more reliable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->